### PR TITLE
Support of composing events

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "source-directories": [
         "src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.1",

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1031,7 +1031,7 @@ viewEditor model =
         ]
         [ viewLineNumbers model
         , viewContent model
-        , H.div [ HA.attribute "style" "overflow:hidden; height:0" ]
+        , H.div [ HA.attribute "style" "overflow:hidden; height:0; outline: none; position: fixed; top:0" ]
             [ H.input
                 [ HA.id "editor_hidden_input"
                 , HE.custom "compositionend" compositionEndDecoder


### PR DESCRIPTION
To support French language characters like "ê (dead key ^ + e)" , one needs to be able to receive composition events. Unfortunately, those events are emitted only for real input texts.

Inspired by Marijn Haverbeke work on Codemirror, (see https://marijnhaverbeke.nl/blog/browser-input-reading.html), this is a pull request which add a hidden 